### PR TITLE
fix: base64 decode AWS Secrets Manager Secrets

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -5,12 +5,12 @@ set -e
 mkdir -p /etc/gitlab/
 
 /usr/bin/aws secretsmanager get-secret-value --secret-id ${SECRET_NAME} | jq --raw-output '.SecretString' > ./secrets.json
-cat secrets.json | jq --raw-output '."ssh_host_ecdsa_key"' > /etc/gitlab/ssh_host_ecdsa_key
-cat secrets.json | jq --raw-output '."ssh_host_ecdsa_key.pub"' > /etc/gitlab/ssh_host_ecdsa_key.pub
-cat secrets.json | jq --raw-output '."ssh_host_ed25519_key"' > /etc/gitlab/ssh_host_ed25519_key
-cat secrets.json | jq --raw-output '."ssh_host_ed25519_key.pub"' > /etc/gitlab/ssh_host_ed25519_key.pub
-cat secrets.json | jq --raw-output '."ssh_host_rsa_key"' > /etc/gitlab/ssh_host_rsa_key
-cat secrets.json | jq --raw-output '."ssh_host_rsa_key.pub"' > /etc/gitlab/ssh_host_rsa_key.pub
+cat secrets.json | jq --raw-output '."ssh_host_ecdsa_key"' | base64 --decode > /etc/gitlab/ssh_host_ecdsa_key
+cat secrets.json | jq --raw-output '."ssh_host_ecdsa_key.pub"' | base64 --decode > /etc/gitlab/ssh_host_ecdsa_key.pub
+cat secrets.json | jq --raw-output '."ssh_host_ed25519_key"' | base64 --decode > /etc/gitlab/ssh_host_ed25519_key
+cat secrets.json | jq --raw-output '."ssh_host_ed25519_key.pub"' | base64 --decode > /etc/gitlab/ssh_host_ed25519_key.pub
+cat secrets.json | jq --raw-output '."ssh_host_rsa_key"' | base64 --decode > /etc/gitlab/ssh_host_rsa_key
+cat secrets.json | jq --raw-output '."ssh_host_rsa_key.pub"' | base64 --decode > /etc/gitlab/ssh_host_rsa_key.pub
 cat secrets.json | jq --raw-output '."gitlab-secrets.json"' > /etc/gitlab/gitlab-secrets.json
 rm ./secrets.json
 


### PR DESCRIPTION
It looks like AWS Secrest Manager doesn't store newlines in its secrets, which doesn't play well with certain public/private key formats. Not sure on the best course of action exactly, but base64-encoding them seems reasonable, and so this change then base64-decodes them.