### PR TITLE
fix: add rds to disallowed extensions

### DIFF
--- a/block-data-files.sh
+++ b/block-data-files.sh
@@ -3,7 +3,7 @@
 # this pre-receive hook checks for data files within all commits during push
 # and posts a warning message with listing all suspected files
 
-disallowed_extensions="csv|tsv|xlsx|xls|parquet|json|xml|png|pdf|rdata"
+disallowed_extensions="csv|tsv|xlsx|xls|parquet|json|xml|png|pdf|rdata|rds"
 disallowed_files=""
 
 while read oldrev newrev refname; do


### PR DESCRIPTION
this is another R data format which we have previously been asked to delete from Gitlab, so adding it to our script too