### PR TITLE
fixing startup folder as it has changed in v17.11

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -33,4 +33,4 @@ chmod +x /etc/gitlab/post-reconfigure.sh
 
 export GITLAB_POST_RECONFIGURE_SCRIPT=/etc/gitlab/post-reconfigure.sh
 
-/assets/wrapper
+/assets/init-container


### PR DESCRIPTION
fixing startup folder to `/assets/init-container` as it has changed in version 17.11